### PR TITLE
[Fixed] `rails g`コマンドの際にhelperとassetsファイルが生成されないよう設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1

Add the followings into config/application.rb

config.generators do |g|
  g.assets false
  g.helper false
end